### PR TITLE
[FIX] Label ID not sorted, fixed by Kao.

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -13,7 +13,7 @@ class PatientDataset(Dataset):
         self.dataset = dataset
         self.tokenizer = tokenizer
         self.len = len(dataset)
-        self.label_map = {label: i for i, label in enumerate(label_set)}
+        self.label_map = {label: i for i, label in enumerate(sorted(label_set))}
         self.id2label = list(label_set)
         self.max_len = config.MAX_LEN
 

--- a/src/train.py
+++ b/src/train.py
@@ -60,18 +60,3 @@ if __name__ == '__main__':
             best_loss = vali_loss
     end = time.time()
     print(f'Training time(s): {end - start}')
-
-    # Evaluation.
-    test_size = int(len(dataset) * config.TEST_RATIO)
-    testset = PatientDataset(dataset[-test_size:], tokenizer, label_set)
-    testloader = DataLoader(testset, batch_size=config.BATCH_SIZE)
-
-    # Evaluate.
-    start = time.time()
-    acc, f1, loss = run_epoch(testloader, model, device)
-    end = time.time()
-    print(f'F1 score: {f1}')
-    print(f'NER acc: {acc}')
-    print(f'Number of sentences: {len(testset)}')
-    print(f'Total time(s): {end - start}')
-    print(f'Time(s) per sentences: {(end - start) / len(testset)}')


### PR DESCRIPTION
We should sort label id in PatientDataset when we extract label using `enumerate` from `label_set` in order to have a stable label id.

This bug was fixed by Kao.